### PR TITLE
Fix some bugs

### DIFF
--- a/derpibooru_dl.py
+++ b/derpibooru_dl.py
@@ -1400,7 +1400,8 @@ def main():
         # Skip everything before and including resumed tag
         logging.info("Skipping all items before the resumed tag: "+resumed_query)
         #logging.debug(str(tag_list))
-        input_file_list = input_file_list[( input_file_list.index(resumed_query) + 1 ):]
+        if resumed_query in input_file_list:
+            input_file_list = input_file_list[( input_file_list.index(resumed_query) + 1 ):]
         #logging.debug(str(input_file_list))
     # Resume range operations
     resume_range_download(settings)


### PR DESCRIPTION
Seems like I encountered a ValueError when I was resuming a download.
The output was:

```
2014-10-30 21:42:39,258 - CRITICAL - Unhandled exception!
2014-10-30 21:42:39,258 - CRITICAL - <type 'exceptions.ValueError'>
2014-10-30 21:42:39,258 - ERROR - 'artist:nuke928' is not in list
Traceback (most recent call last):
  File "derpibooru_dl.py", line 1427, in <module>
    main()
  File "derpibooru_dl.py", line 1403, in main
    input_file_list = input_file_list[( input_file_list.index(resumed_query) + 1 ):]
ValueError: 'artist:nuke928' is not in list

```
