### PR TITLE
Integrate changes by oblivion2k

### DIFF
--- a/derpibooru_dl.py
+++ b/derpibooru_dl.py
@@ -230,8 +230,7 @@ def import_list(listfilename="ERROR.txt"):
                     stripped_line = line[:-1]
                 else:
                     stripped_line = line# If no trailing newline exists, we dont need to strip it
-                replaced_line = re.sub(" ", "+", stripped_line)# Replace spaces with plusses
-                query_list.append(replaced_line)# Add the username to the list
+                query_list.append(stripped_line)# Add the username to the list
         list_file.close()
         return query_list
     else: # If there is no list, make one


### PR DESCRIPTION
"Eliminates the bug preventing users from downloading tags in derpibooru_dl_tag_list.txt that contain spaces (ex. Princess Luna, Shining Armor, etc.) Simply rename to Derpibooru_dl.py and replace your existing file with this file, or wait for Woodenphone to pull this into the master release.

Technical changes:
Deleted line 231, as the Derpiboo.ru API now properly handles spaces in tag searches without the need to convert spaces to '+' first.
Changed line 231 (previously 232) to append the query_list with stripped_line, as replaced_line is no longer needed."